### PR TITLE
Pass in more annotation data, skip rendering them and popups

### DIFF
--- a/src/core/annotation.js
+++ b/src/core/annotation.js
@@ -458,6 +458,8 @@ class Annotation {
       this._streams.push(this.appearance);
     }
 
+    const defaultAppearance = dict.get("DA") || null;
+
     // Expose public properties using a data object.
     this.data = {
       annotationFlags: this.flags,
@@ -473,6 +475,7 @@ class Annotation {
       rect: this.rectangle,
       subtype: params.subtype,
       hasOwnCanvas: false,
+      defaultAppearance
     };
 
     if (params.collectFields) {

--- a/src/core/annotation.js
+++ b/src/core/annotation.js
@@ -134,7 +134,6 @@ class AnnotationFactory {
       collectFields,
       pageIndex,
     };
-    console.log(parameters);
 
     switch (subtype) {
       case "Link":

--- a/src/core/annotation.js
+++ b/src/core/annotation.js
@@ -134,6 +134,7 @@ class AnnotationFactory {
       collectFields,
       pageIndex,
     };
+    console.log(parameters);
 
     switch (subtype) {
       case "Link":
@@ -459,6 +460,8 @@ class Annotation {
     }
 
     const defaultAppearance = dict.get("DA") || null;
+    const rawColor = dict.get("C") || null;
+    const rawInteriorColor = dict.get("IC") || null;
 
     // Expose public properties using a data object.
     this.data = {
@@ -475,7 +478,9 @@ class Annotation {
       rect: this.rectangle,
       subtype: params.subtype,
       hasOwnCanvas: false,
-      defaultAppearance
+      defaultAppearance,
+      rawColor,
+      rawInteriorColor,
     };
 
     if (params.collectFields) {
@@ -878,6 +883,17 @@ class Annotation {
     annotationStorage
   ) {
     const data = this.data;
+
+    // We won't render these to the canvas, but instead activate them as
+    // placeables
+    if (["FreeText", "Square", "Circle", "Polygon"].includes(this.data.subtype)) {
+      return {
+        opList: new OperatorList(),
+        separateForm: false,
+        separateCanvas: false,
+      };
+    }
+
     let appearance = this.appearance;
     const isUsingOwnCanvas = !!(
       this.data.hasOwnCanvas && intent & RenderingIntentFlag.DISPLAY
@@ -899,6 +915,7 @@ class Annotation {
       ["ExtGState", "ColorSpace", "Pattern", "Shading", "XObject", "Font"],
       appearance
     );
+
     const bbox = appearanceDict.getArray("BBox") || [0, 0, 1, 1];
     const matrix = appearanceDict.getArray("Matrix") || [1, 0, 0, 1, 0, 0];
     const transform = getTransformMatrix(data.rect, bbox, matrix);

--- a/src/display/annotation_layer.js
+++ b/src/display/annotation_layer.js
@@ -459,6 +459,9 @@ class AnnotationElement {
    * @memberof AnnotationElement
    */
   _createPopup(trigger, data) {
+    // we dont want to render any of the floating popup for annotation metadata
+    return;
+
     let container = this.container;
     if (this.quadrilaterals) {
       trigger = trigger || this.quadrilaterals;

--- a/src/display/annotation_layer.js
+++ b/src/display/annotation_layer.js
@@ -462,35 +462,35 @@ class AnnotationElement {
     // we dont want to render any of the floating popup for annotation metadata
     return;
 
-    let container = this.container;
-    if (this.quadrilaterals) {
-      trigger = trigger || this.quadrilaterals;
-      container = this.quadrilaterals[0];
-    }
+    // let container = this.container;
+    // if (this.quadrilaterals) {
+    //   trigger = trigger || this.quadrilaterals;
+    //   container = this.quadrilaterals[0];
+    // }
 
-    // If no trigger element is specified, create it.
-    if (!trigger) {
-      trigger = document.createElement("div");
-      trigger.className = "popupTriggerArea";
-      container.append(trigger);
-    }
+    // // If no trigger element is specified, create it.
+    // if (!trigger) {
+    //   trigger = document.createElement("div");
+    //   trigger.className = "popupTriggerArea";
+    //   container.append(trigger);
+    // }
 
-    const popupElement = new PopupElement({
-      container,
-      trigger,
-      color: data.color,
-      titleObj: data.titleObj,
-      modificationDate: data.modificationDate,
-      contentsObj: data.contentsObj,
-      richText: data.richText,
-      hideWrapper: true,
-    });
-    const popup = popupElement.render();
+    // const popupElement = new PopupElement({
+    //   container,
+    //   trigger,
+    //   color: data.color,
+    //   titleObj: data.titleObj,
+    //   modificationDate: data.modificationDate,
+    //   contentsObj: data.contentsObj,
+    //   richText: data.richText,
+    //   hideWrapper: true,
+    // });
+    // const popup = popupElement.render();
 
-    // Position the popup next to the annotation's container.
-    popup.style.left = "100%";
+    // // Position the popup next to the annotation's container.
+    // popup.style.left = "100%";
 
-    container.append(popup);
+    // container.append(popup);
   }
 
   /**


### PR DESCRIPTION
This adds a few attributes about annotations we want available outside of pdfjs (defaultAppearance, rawColor, rawInteriorColor), they are just added onto the data payload.

Then we skip rendering annotations of type FreeText/Square/Circle/Polygon since the frontend will render those as placeables.

Lastly, we are going to skip rendering the yellow popups altogether (has annotation data like name and timestamps- we just don't want that)


https://github.com/coparse-inc/pdf.js/assets/6100/0d4ee2df-cd23-4a28-a4c6-51dc6decda81


https://github.com/coparse-inc/pdf.js/assets/6100/1c69c93b-11b0-41b3-a4d5-0f65a8937dc4


https://github.com/coparse-inc/pdf.js/assets/6100/8cfdc6a6-6e23-4f1b-8b0b-220ba9dd5ed6



